### PR TITLE
[ Variables ] - Add missing documentation for repository variables

### DIFF
--- a/src/beginner/index.md
+++ b/src/beginner/index.md
@@ -93,6 +93,14 @@ act -j 'test'
 
 > This example will run **all jobs** named `test` in **all workflows** that trigger on `push` event
 
+# Vars
+
+To run `act` with repository variables that are acessible inside the workflow via ${{ vars.VARIABLE }}, you can enter them interactively or load them from a file. The following options are available for providing github repository variables:
+
+- `act --var VARIABLE=somevalue` - use `somevalue` as the value for `VARIABLE`.
+- `act --var-file my.variables` - load variables values from `my.variables` file.
+- The variables file format is the same as `.env` format
+
 ## Secrets
 
 To run `act` with secrets, you can enter them interactively, supply them as environment variables or load them from a file. The following options are available for providing secrets:


### PR DESCRIPTION
As seen in this [issue](https://github.com/nektos/act/issues/1558) the support for variables was made months ago, but the documentation does not have this information

Why update this: at least for me, the only way to discover this functionality existed was searching and finding the mentioned issue above

Reference for the updated section:
![image](https://github.com/nektos/act-docs/assets/65742620/2f6a6a1c-0241-4ef7-bf10-09657041aa4e)
