### PR TITLE
Resolving Content Alignment Issue with "Jump to Previous" and "Jump to Next" Buttons

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,6 +4,3 @@ language = "en"
 multilingual = false
 src = "src"
 title = "act - User Guide"
-
-[output.html]
-additional-css = ["custom.css"]

--- a/custom.css
+++ b/custom.css
@@ -1,3 +1,0 @@
-:root {
-    --content-max-width: 1280px
-}


### PR DESCRIPTION
This pull request resolves [issue #15,](https://github.com/nektos/act-docs/issues/15) where the content alignment within the body of the page was not properly configured. Specifically, the "Jump to Previous" and "Jump to Next" buttons were colliding with the main text of the body, resulting in inconsistencies in the display and functionality of the page. 

To fix this issue, I have adjusted the CSS to remove the fixed length assigned to the root element, allowing for proper alignment and spacing throughout the page.

This resolves the alignment inconsistencies and restores the intended functionality of the page. Please review and merge accordingly.

Thank you.

https://github.com/nektos/act-docs/assets/86195162/bf4efe92-2c3f-4269-af0a-9e4f7df8a82a




