### PR TITLE
fix: improve page title for better searching in browser searchbar

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -3,4 +3,4 @@ authors = ["Casey Lee"]
 language = "en"
 multilingual = false
 src = "src"
-title = "act - User Guide"
+title = "act - User Guide | Manual | Docs | Documentation"


### PR DESCRIPTION
I often go back into docs by typing in the search bar of my browser: `<pkg> docs` but `act` is missing these words in the title and can't be found