### PR TITLE
Add Gradle act plugin to the list of `act` integrations

### DIFF
--- a/src/integrations.md
+++ b/src/integrations.md
@@ -4,3 +4,4 @@
 
 - [Gitea Actions runner](https://gitea.com/gitea/act_runner)
 - [github-act-runner](https://github.com/ChristopherHX/github-act-runner)
+- [Gradle Act plugin](https://github.com/pshevche/gradle-act-plugin)


### PR DESCRIPTION
## Description

_Doing some self-advertisement here_

Adding a reference to the Gradle Act plugin that allows users to define specifications for testing their Github workflows using `act`. The plugin's verification tasks can be integrated into the build lifecycle, will run workflows according to spec files and create user-friendly reports.

Resolves https://github.com/nektos/act/issues/2411