### PR TITLE
Update AUR documentation since the package got moved to Arch Extra

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,7 +2,7 @@
 
 - [Introduction](./introduction.md)
 - [Installation](./installation/index.md)
-  - [AUR](./installation/aur.md)
+  - [Arch](./installation/arch.md)
   - [Chocolatey](./installation/chocolatey.md)
   - [COPR](./installation/copr.md)
   - [GitHub CLI](./installation/gh.md)

--- a/src/installation/arch.md
+++ b/src/installation/arch.md
@@ -3,5 +3,5 @@
 [![arch-shield](https://img.shields.io/archlinux/v/extra/x86_64/act)](https://archlinux.org/packages/extra/x86_64/act/)
 
 ```shell
-pacman -S act
+pacman -Syu act
 ```

--- a/src/installation/arch.md
+++ b/src/installation/arch.md
@@ -1,0 +1,7 @@
+# [Arch](https://archlinux.org/packages/extra/x86_64/act/) (Linux)
+
+[![arch-shield](https://img.shields.io/archlinux/v/extra/x86_64/act)](https://archlinux.org/packages/extra/x86_64/act/)
+
+```shell
+pacman -S act
+```

--- a/src/installation/aur.md
+++ b/src/installation/aur.md
@@ -1,7 +1,0 @@
-# [AUR](https://aur.archlinux.org/packages/act/) (Linux)
-
-[![aur-shield](https://img.shields.io/aur/version/act)](https://aur.archlinux.org/packages/act/)
-
-```shell
-yay -Syu act
-```

--- a/src/installation/index.md
+++ b/src/installation/index.md
@@ -59,7 +59,7 @@ go build -ldflags "-X main.version=$(git describe --tags --dirty --always | sed 
 
 `act` is available in below package repositories
 
-- [AUR](./aur.md) (`Linux`)
+- [Arch](./arch.md) (`Linux`)
 - [Homebrew](./homebrew.md) (`Linux`, `macOS`)
 - [Chocolatey](./chocolatey.md) (`Windows`)
 - [COPR](./copr.md) (`Linux`)


### PR DESCRIPTION
Arch upgraded `act` from the AUR to its "Extra" repository. This PR changes the documentation accordingly.

This is an alternative to #20. The reason for this is that, in my opinion, _Arch_ is the better name over _pacman_ for these reasons:
- The package is in the [Arch Extra](https://archlinux.org/packages/extra/x86_64/act/) repository not in [Manjaro Extra](https://gitlab.manjaro.org/packages/extra) or any other.
- Pacman is a package manager, not a repository. The installation sections starts with

  > … below package repositories:

  In addition, pacman could be pointed to non-arch repos that do not include `act`.
- I believe the usage of the term _Arch Linux_ is more common than _Pacman_ when installation instructions are provided.