### PR TITLE
add docs source to html page

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "src"
 title = "act - User Guide | Manual | Docs | Documentation"
+
+[output.html]
+git-repository-url = "https://github.com/nektos/act-docs"


### PR DESCRIPTION
Per `https://github.com/rust-lang/mdBook/pull/802/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR579`

No idea if this works right now, didn't test

Documented here as well https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options

After testing, this should work and add a github icon on the top-right menu