### PR TITLE
Add page edit direct link to documentation

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -7,3 +7,4 @@ title = "act - User Guide | Manual | Docs | Documentation"
 
 [output.html]
 git-repository-url = "https://github.com/nektos/act-docs"
+edit-url-template = "https://github.com/nektos/act-docs/edit/main/{path}"


### PR DESCRIPTION
Currently you need to open the page md file manually, now you have a direct link known from ms docs, github docs and readthedocs