### PR TITLE
docs: replace docker desktop with orbstack

### DIFF
--- a/src/installation/index.md
+++ b/src/installation/index.md
@@ -4,7 +4,7 @@
 
 `act` depends on `docker` (exactly Docker Engine API) to run workflows in containers. As long you don't require container isolation, you can run selected (e.g. windows or macOS) jobs directly on your System, see [Runners](../usage/runners.md). In the latter case you don't need to have docker installed or running.
 
-If you are using macOS, please be sure to follow the steps outlined in [Docker Docs for how to install Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/install/).
+If you are using macOS, you can install docker by setting up OrbStack (https://orbstack.dev/).
 
 If you are using Windows, please follow steps for [installing Docker Desktop on Windows](https://docs.docker.com/docker-for-windows/install/).
 


### PR DESCRIPTION
Docker Desktop has many issues with regard to flagging security software, speed, and generally being pretty bulky. Orbstack is a much lighter weight alternative. See here: https://docs.orbstack.dev/compare/docker-desktop