### PR TITLE
Add `act-test-runner` package to the list of integrations

### DIFF
--- a/src/integrations.md
+++ b/src/integrations.md
@@ -4,5 +4,5 @@
 
 - [Gitea Actions runner](https://gitea.com/gitea/act_runner)
 - [github-act-runner](https://github.com/ChristopherHX/github-act-runner)
-- [Gradle Act plugin](https://github.com/pshevche/gradle-act-plugin)
+- [act-test-runner](https://github.com/pshevche/act-test-runner)
 - [GitHub Local Actions for Visual Studio Code](https://sanjulaganepola.github.io/github-local-actions-docs/)


### PR DESCRIPTION
## Context

I am the maintainer of both integrations and decided to deprecate the Gradle plugin in favor of an NPM package, as this is the more likely integration that my target audience (i.e., developers of GitHub actions) will use to implement end-to-end tests.